### PR TITLE
Move Contact Us outside Sign up/in Dropdown Menu

### DIFF
--- a/hotelontouch/src/components/NavbarComponent.js
+++ b/hotelontouch/src/components/NavbarComponent.js
@@ -30,9 +30,9 @@ function NavbarComponent() {
         <Nav className="mr-auto">
           <NavDropdown title="SignUp/SignIn" id="collasible-nav-dropdown">
             <NavDropdown.Item href="#action/3.1">Register</NavDropdown.Item>
-            <NavDropdown.Item href="#action/3.2">Login</NavDropdown.Item>
-            <NavDropdown.Item as={Link} to='/contact'>Contact Us</NavDropdown.Item>         
+            <NavDropdown.Item href="#action/3.2">Login</NavDropdown.Item>        
           </NavDropdown>
+          <Button variant="outline-info" as={Link} to='/contact'>Contact Us</Button>
         </Nav>
         <Form inline>
           <FormControl type="text" placeholder="Search" className="mr-sm-2" />


### PR DESCRIPTION
Fixes #203 

#### Changes done
Moved the contact us link out from the dropdown menu, and made it a button instead

Screenshots of the changes (If any) -
Refer to linked issue for screenshot

#### ✅️ By submitting this PR, I have verified the following
- [X] Worked on forked repo and starred the main repo
- [X] Checked to see if a similar PR has already been opened 🤔️
- [X] Reviewed the contributing guidelines 🔍️
- [X] Sample preview link added (add the link(s) for all the pages changed/updated from the checks tab after checks complete)
- [X] Tried Squashing the commits into one
